### PR TITLE
Fix "Failed to generate BTF for vmlinux" error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,8 @@
 set -e
 set -o pipefail
 
-sudo apt install build-essential flex bison libssl-dev libelf-dev libncurses-dev autoconf libudev-dev libtool
+sudo apt update
+sudo apt install build-essential flex bison libssl-dev libelf-dev libncurses-dev autoconf libudev-dev libtool dwarves
 
 WSL2_KERNEL_VERSION="$(uname -r | grep -o '^[0-9\.]\+')"
 


### PR DESCRIPTION
Fix for
```
BTF: .tmp_vmlinux.btf: pahole (pahole) is not available Failed to generate BTF for vmlinux
Try to disable CONFIG_DEBUG_INFO_BTF
make: *** [Makefile:1179: vmlinux] Error 1
```

This pull request includes an update to the `build.sh` script, which enhances the setup process by ensuring the package lists are updated before installing dependencies and adding a new dependency.

Changes to the setup process:

* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L8-R9): Added `sudo apt update` to ensure package lists are up-to-date before installing dependencies.
* [`build.sh`](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L8-R9): Added `dwarves` to the list of dependencies to be installed.