### PR TITLE
fix typo in zswap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wsl2-kernel-zswap
 
-WSL2 kernel with zwap.
+WSL2 kernel with zswap.
 
 Tested on Ubuntu 22.04 with kernel 5.15.153.1-microsoft-standard-WSL2.
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Build a custom WSL2 kernel with zwap
+# Build a custom WSL2 kernel with zswap
 
 set -e
 set -o pipefail


### PR DESCRIPTION
This pull request includes a small correction to the `README.md` file. The change fixes a typo in the description, replacing "zwap" with "zswap" to accurately reflect the feature name.