### PR TITLE
Add support for kernel 6.x and modules vhdx

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ Tested on:
 
 # Building
 
+## Quick Start (review script first recommended)
+
+```bash
+# Download and review the script first
+curl -O https://raw.githubusercontent.com/crramirez/wsl2-kernel-zswap/main/build.sh
+less build.sh
+
+# After reviewing, run it
+bash build.sh
+```
+
+## One-liner (use at your own risk)
+
 ```bash
 curl https://raw.githubusercontent.com/crramirez/wsl2-kernel-zswap/main/build.sh | bash
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ bash build.sh
 
 ## One-liner (use at your own risk)
 
+> ⚠️ **Security Warning:**  
+> Piping a remotely fetched script directly to `bash` is risky.  
+> **Before running this command,** you should:
+> - Inspect the script at [build.sh](https://raw.githubusercontent.com/crramirez/wsl2-kernel-zswap/main/build.sh) in your browser.
+> - Optionally, verify its integrity using a checksum or signature if available.
+> - Only proceed if you trust the source and have reviewed the script.
+
 ```bash
 curl https://raw.githubusercontent.com/crramirez/wsl2-kernel-zswap/main/build.sh | bash
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Tested on:
 
 ```bash
 # Download and review the script first
-curl -O https://raw.githubusercontent.com/crramirez/wsl2-kernel-zswap/main/build.sh
+curl -O https://raw.githubusercontent.com/dhanar10/wsl2-kernel-zswap/main/build.sh
 less build.sh
 
 # After reviewing, run it
@@ -22,7 +22,7 @@ bash build.sh
 ## One-liner (use at your own risk)
 
 ```bash
-curl https://raw.githubusercontent.com/crramirez/wsl2-kernel-zswap/main/build.sh | bash
+curl https://raw.githubusercontent.com/dhanar10/wsl2-kernel-zswap/main/build.sh | bash
 ```
 
 The script automatically detects your kernel version and:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ curl https://raw.githubusercontent.com/crramirez/wsl2-kernel-zswap/main/build.sh
 
 The script automatically detects your kernel version and:
 - For kernel 5.x: builds the kernel with CONFIG_FRONTSWAP support
-- For kernel 6.x: builds the kernel without CONFIG_FRONTSWAP (removed in 6.x) and generates a modules.tar.gz file containing kernel modules
+- For kernel 6.x: builds the kernel without CONFIG_FRONTSWAP (removed in 6.x) and generates a modules.vhdx file containing kernel modules
 
 # Installation
 
@@ -47,17 +47,14 @@ Then restart WSL: `wsl --shutdown`
 After building:
 
 1. Copy `arch/x86/boot/bzImage` to `/mnt/c/bzImage`
-2. Copy `modules.tar.gz` to `/mnt/c/modules.tar.gz`
+2. Copy `modules.vhdx` to `/mnt/c/modules.vhdx`
 3. Configure `.wslconfig` in your Windows user directory:
    ```
    [wsl2]
    kernel=C:\\bzImage
+   kernelModules=C:\\modules.vhdx
    ```
-4. Extract modules in your WSL2 instance:
-   ```bash
-   sudo tar -xzf /mnt/c/modules.tar.gz -C /
-   ```
-5. Restart WSL: `wsl --shutdown`
+4. Restart WSL: `wsl --shutdown`
 
 # Verifying zswap
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,58 @@
 
 WSL2 kernel with zswap.
 
-Tested on Ubuntu 22.04 with kernel 5.15.153.1-microsoft-standard-WSL2.
+Tested on:
+- Ubuntu 22.04 with kernel 5.15.153.1-microsoft-standard-WSL2 (kernel 5.x)
+- Ubuntu with kernel 6.x-microsoft-standard-WSL2 (kernel 6.x)
 
 # Building
 
+```bash
+curl https://raw.githubusercontent.com/crramirez/wsl2-kernel-zswap/main/build.sh | bash
 ```
-curl https://raw.githubusercontent.com/dhanar10/wsl2-kernel-zswap/main/build.sh | bash
+
+The script automatically detects your kernel version and:
+- For kernel 5.x: builds the kernel with CONFIG_FRONTSWAP support
+- For kernel 6.x: builds the kernel without CONFIG_FRONTSWAP (removed in 6.x) and generates a modules.tar.gz file containing kernel modules
+
+# Installation
+
+## Kernel 5.x
+
+After building, copy `arch/x86/boot/bzImage` to your Windows C: drive and configure `.wslconfig`:
+
+```
+[wsl2]
+kernel=C:\\bzImage
+```
+
+Then restart WSL: `wsl --shutdown`
+
+## Kernel 6.x
+
+After building:
+
+1. Copy `arch/x86/boot/bzImage` to `/mnt/c/bzImage`
+2. Copy `modules.tar.gz` to `/mnt/c/modules.tar.gz`
+3. Configure `.wslconfig` in your Windows user directory:
+   ```
+   [wsl2]
+   kernel=C:\\bzImage
+   ```
+4. Extract modules in your WSL2 instance:
+   ```bash
+   sudo tar -xzf /mnt/c/modules.tar.gz -C /
+   ```
+5. Restart WSL: `wsl --shutdown`
+
+# Verifying zswap
+
+After restarting WSL, verify zswap is enabled:
+
+```bash
+cat /sys/module/zswap/parameters/enabled
+# Should output: Y
+
+cat /sys/module/zswap/parameters/compressor
+# Should output: zstd
 ```

--- a/README.md
+++ b/README.md
@@ -21,13 +21,6 @@ bash build.sh
 
 ## One-liner (use at your own risk)
 
-> ⚠️ **Security Warning:**  
-> Piping a remotely fetched script directly to `bash` is risky.  
-> **Before running this command,** you should:
-> - Inspect the script at [build.sh](https://raw.githubusercontent.com/crramirez/wsl2-kernel-zswap/main/build.sh) in your browser.
-> - Optionally, verify its integrity using a checksum or signature if available.
-> - Only proceed if you trust the source and have reviewed the script.
-
 ```bash
 curl https://raw.githubusercontent.com/crramirez/wsl2-kernel-zswap/main/build.sh | bash
 ```

--- a/build.sh
+++ b/build.sh
@@ -67,6 +67,14 @@ if [[ "${KERNEL_MAJOR_VERSION}" -ge 6 ]]; then
   # Save current directory
   BUILD_DIR=$(pwd)
 
+  # Set up cleanup trap to ensure modules directory is removed on error
+  cleanup_modules() {
+    if [[ -d "${BUILD_DIR}/modules" ]]; then
+      rm -rf "${BUILD_DIR}/modules"
+    fi
+  }
+  trap cleanup_modules EXIT
+
   # Install modules to a modules directory
   if ! make modules_install INSTALL_MOD_PATH="${BUILD_DIR}/modules"; then
     echo "Error: Failed to install kernel modules"
@@ -75,16 +83,22 @@ if [[ "${KERNEL_MAJOR_VERSION}" -ge 6 ]]; then
 
   # Get kernel release version
   KERNEL_RELEASE=$(make -s kernelrelease)
+  
+  # Validate kernel release was extracted correctly
+  if [[ -z "${KERNEL_RELEASE}" ]]; then
+    echo "Error: Could not determine kernel release version"
+    exit 1
+  fi
 
   # Use Microsoft's gen_modules_vhdx.sh script
   echo "Creating modules VHDX using Microsoft's gen_modules_vhdx.sh script..."
   if ! sudo ./Microsoft/scripts/gen_modules_vhdx.sh "${BUILD_DIR}/modules" "${KERNEL_RELEASE}" "${BUILD_DIR}/modules.vhdx"; then
     echo "Error: Failed to create modules VHDX"
-    rm -rf "${BUILD_DIR}/modules"
     exit 1
   fi
 
-  # Cleanup modules directory
+  # Cleanup modules directory and remove trap
+  trap - EXIT
   rm -rf "${BUILD_DIR}/modules"
 
   cat << EOF

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ set -e
 set -o pipefail
 
 sudo apt update
-sudo apt install build-essential flex bison libssl-dev libelf-dev libncurses-dev autoconf libudev-dev libtool dwarves
+sudo apt install build-essential flex bison libssl-dev libelf-dev libncurses-dev autoconf libudev-dev libtool dwarves cpio qemu-utils
 
 WSL2_KERNEL_VERSION="$(uname -r | grep -o '^[0-9\.]\+')"
 KERNEL_MAJOR_VERSION="$(echo "${WSL2_KERNEL_VERSION}" | cut -d. -f1)"
@@ -64,29 +64,52 @@ make -j $(nproc)
 if [ "$KERNEL_MAJOR_VERSION" -ge 6 ]; then
     echo "Building and packaging kernel modules for WSL2 kernel 6.x..."
     
-    # Create temporary directory for modules installation
-    if ! MODULES_TEMP=$(mktemp -d); then
+    # Save current directory
+    BUILD_DIR=$(pwd)
+    
+    # Install modules to a modules directory
+    if ! make modules_install INSTALL_MOD_PATH="${BUILD_DIR}/modules"; then
+        echo "Error: Failed to install kernel modules"
+        exit 1
+    fi
+    
+    # Get kernel release version
+    KERNEL_RELEASE=$(make -s kernelrelease)
+    
+    # Create VHDX containing the modules
+    echo "Creating modules VHDX..."
+    
+    # Calculate modules size (+ 256MiB for slack)
+    MODULES_SIZE=$(du -bs "${BUILD_DIR}/modules" | awk '{print $1;}')
+    MODULES_SIZE=$((MODULES_SIZE + (256*(1<<20))))
+    
+    # Create temporary directory for VHDX creation
+    if ! TMP_DIR=$(mktemp -d); then
         echo "Error: Failed to create temporary directory"
         exit 1
     fi
     
-    # Save current directory
-    BUILD_DIR=$(pwd)
+    # Create a blank image file
+    dd if=/dev/zero of="${TMP_DIR}/modules.img" bs=1024 count=$((MODULES_SIZE / 1024)) status=progress
     
-    # Install modules to temporary directory
-    if ! make modules_install INSTALL_MOD_PATH="${MODULES_TEMP}"; then
-        echo "Error: Failed to install kernel modules"
-        rm -rf "${MODULES_TEMP}"
-        exit 1
-    fi
+    # Set up filesystem and mount
+    LO_DEV=$(sudo losetup --find --show "${TMP_DIR}/modules.img")
+    sudo mkfs -t ext4 "${LO_DEV}"
+    mkdir "${TMP_DIR}/modules_img"
+    sudo mount "${LO_DEV}" "${TMP_DIR}/modules_img"
+    sudo chmod a+rw "${TMP_DIR}/modules_img"
     
-    # Create tar.gz archive of modules directly in build directory
-    cd "${MODULES_TEMP}"
-    tar -czf "${BUILD_DIR}/modules.tar.gz" lib/
-    cd "${BUILD_DIR}"
+    # Copy over the modules
+    sudo cp -r "${BUILD_DIR}/modules/lib/modules/${KERNEL_RELEASE}"/* "${TMP_DIR}/modules_img"
+    sudo umount "${TMP_DIR}/modules_img"
+    sudo losetup -d "${LO_DEV}"
     
-    # Cleanup
-    rm -rf "${MODULES_TEMP}"
+    # Convert to VHDX
+    qemu-img convert -O vhdx "${TMP_DIR}/modules.img" "${BUILD_DIR}/modules.vhdx"
+    
+    # Cleanup temporary files
+    rm -rf "${TMP_DIR}"
+    rm -rf "${BUILD_DIR}/modules"
     
     cat << EOF
 
@@ -94,16 +117,14 @@ Kernel build complete for WSL2 kernel ${WSL2_KERNEL_VERSION}!
 
 Next steps:
 1. Copy "arch/x86/boot/bzImage" to "/mnt/c/bzImage"
-2. Copy "modules.tar.gz" to "/mnt/c/modules.tar.gz"
+2. Copy "modules.vhdx" to "/mnt/c/modules.vhdx"
 3. Add the following to your ".wslconfig" file in your Windows user directory:
 
 [wsl2]
 kernel=C:\\\\bzImage
+kernelModules=C:\\\\modules.vhdx
 
-4. Extract the modules in your WSL2 instance:
-   sudo tar -xzf /mnt/c/modules.tar.gz -C /
-
-5. Restart your WSL2 instance:
+4. Restart your WSL2 instance:
    wsl --shutdown
    
 Then reopen your WSL2 terminal. The new kernel with zswap support will be active.

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ sudo apt update
 sudo apt install build-essential flex bison libssl-dev libelf-dev libncurses-dev autoconf libudev-dev libtool dwarves
 
 WSL2_KERNEL_VERSION="$(uname -r | grep -o '^[0-9\.]\+')"
+KERNEL_MAJOR_VERSION="$(echo ${WSL2_KERNEL_VERSION} | cut -d. -f1)"
 
 wget -c https://github.com/microsoft/WSL2-Linux-Kernel/archive/refs/tags/linux-msft-wsl-${WSL2_KERNEL_VERSION}.tar.gz
 tar xvf linux-msft-wsl-${WSL2_KERNEL_VERSION}.tar.gz
@@ -16,7 +17,11 @@ tar xvf linux-msft-wsl-${WSL2_KERNEL_VERSION}.tar.gz
 cd "WSL2-Linux-Kernel-linux-msft-wsl-${WSL2_KERNEL_VERSION}"
 
 cp Microsoft/config-wsl .config           # Use WSL default kernel config as the base
-cat << EOF >> .config
+
+# Add zswap configuration based on kernel version
+if [ "$KERNEL_MAJOR_VERSION" -lt 6 ]; then
+    # Kernel 5.x configuration with CONFIG_FRONTSWAP
+    cat << EOF >> .config
 
 CONFIG_CRYPTO_ZSTD=y
 CONFIG_ZSTD_COMMON=y
@@ -32,18 +37,85 @@ CONFIG_ZSWAP_DEFAULT_ON=y
 CONFIG_ZPOOL=y
 CONFIG_ZBUD=y
 EOF
+else
+    # Kernel 6.x configuration (CONFIG_FRONTSWAP removed)
+    cat << EOF >> .config
+
+CONFIG_CRYPTO_ZSTD=y
+CONFIG_ZSTD_COMMON=y
+CONFIG_ZSTD_COMPRESS=y
+
+CONFIG_ZSWAP=y
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT_ZSTD=y
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT="zstd"
+CONFIG_ZSWAP_ZPOOL_DEFAULT_ZBUD=y
+CONFIG_ZSWAP_ZPOOL_DEFAULT="zbud"
+CONFIG_ZSWAP_DEFAULT_ON=y
+CONFIG_ZPOOL=y
+CONFIG_ZBUD=y
+EOF
+fi
+
 make olddefconfig
 
 make -j $(nproc)
 
-cat << EOF
+# For kernel 6.x, also build and package modules
+if [ "$KERNEL_MAJOR_VERSION" -ge 6 ]; then
+    echo "Building and packaging kernel modules for WSL2 kernel 6.x..."
+    
+    # Create temporary directory for modules installation
+    MODULES_TEMP=$(mktemp -d)
+    
+    # Install modules to temporary directory
+    make modules_install INSTALL_MOD_PATH="${MODULES_TEMP}"
+    
+    # Create tar.gz archive of modules
+    cd "${MODULES_TEMP}"
+    tar -czf ../modules.tar.gz lib/
+    cd -
+    
+    # Move modules archive to a convenient location
+    mv "${MODULES_TEMP}/../modules.tar.gz" ./modules.tar.gz
+    
+    # Cleanup
+    rm -rf "${MODULES_TEMP}"
+    
+    cat << EOF
 
-Next, copy "arch/x86/boot/bzImage" to "/mnt/c" and 
-add the following to your ".wslconfig".
+Kernel build complete for WSL2 kernel ${WSL2_KERNEL_VERSION}!
+
+Next steps:
+1. Copy "arch/x86/boot/bzImage" to "/mnt/c/bzImage"
+2. Copy "modules.tar.gz" to "/mnt/c/modules.tar.gz"
+3. Add the following to your ".wslconfig" file in your Windows user directory:
 
 [wsl2]
 kernel=C:\\\\bzImage
 
-After that, restart your WSL2 instance by executing 
-"wsl --shutdown" and then reopening your WSL2 terminal.
+4. Extract the modules in your WSL2 instance:
+   sudo tar -xzf /mnt/c/modules.tar.gz -C /
+
+5. Restart your WSL2 instance:
+   wsl --shutdown
+   
+Then reopen your WSL2 terminal. The new kernel with zswap support will be active.
 EOF
+else
+    cat << EOF
+
+Kernel build complete for WSL2 kernel ${WSL2_KERNEL_VERSION}!
+
+Next steps:
+1. Copy "arch/x86/boot/bzImage" to "/mnt/c/bzImage"
+2. Add the following to your ".wslconfig" file in your Windows user directory:
+
+[wsl2]
+kernel=C:\\\\bzImage
+
+3. Restart your WSL2 instance:
+   wsl --shutdown
+
+Then reopen your WSL2 terminal. The new kernel with zswap support will be active.
+EOF
+fi

--- a/build.sh
+++ b/build.sh
@@ -65,8 +65,7 @@ if [ "$KERNEL_MAJOR_VERSION" -ge 6 ]; then
     echo "Building and packaging kernel modules for WSL2 kernel 6.x..."
     
     # Create temporary directory for modules installation
-    MODULES_TEMP=$(mktemp -d)
-    if [ -z "${MODULES_TEMP}" ]; then
+    if ! MODULES_TEMP=$(mktemp -d); then
         echo "Error: Failed to create temporary directory"
         exit 1
     fi

--- a/build.sh
+++ b/build.sh
@@ -66,17 +66,21 @@ if [ "$KERNEL_MAJOR_VERSION" -ge 6 ]; then
     
     # Create temporary directory for modules installation
     MODULES_TEMP=$(mktemp -d)
+    if [ ! -d "${MODULES_TEMP}" ]; then
+        echo "Error: Failed to create temporary directory"
+        exit 1
+    fi
+    
+    # Save current directory
+    BUILD_DIR=$(pwd)
     
     # Install modules to temporary directory
     make modules_install INSTALL_MOD_PATH="${MODULES_TEMP}"
     
-    # Create tar.gz archive of modules
+    # Create tar.gz archive of modules directly in build directory
     cd "${MODULES_TEMP}"
-    tar -czf ../modules.tar.gz lib/
-    cd -
-    
-    # Move modules archive to a convenient location
-    mv "${MODULES_TEMP}/../modules.tar.gz" ./modules.tar.gz
+    tar -czf "${BUILD_DIR}/modules.tar.gz" lib/
+    cd "${BUILD_DIR}"
     
     # Cleanup
     rm -rf "${MODULES_TEMP}"

--- a/build.sh
+++ b/build.sh
@@ -76,39 +76,15 @@ if [ "$KERNEL_MAJOR_VERSION" -ge 6 ]; then
     # Get kernel release version
     KERNEL_RELEASE=$(make -s kernelrelease)
     
-    # Create VHDX containing the modules
-    echo "Creating modules VHDX..."
-    
-    # Calculate modules size (+ 256MiB for slack)
-    MODULES_SIZE=$(du -bs "${BUILD_DIR}/modules" | awk '{print $1;}')
-    MODULES_SIZE=$((MODULES_SIZE + (256*(1<<20))))
-    
-    # Create temporary directory for VHDX creation
-    if ! TMP_DIR=$(mktemp -d); then
-        echo "Error: Failed to create temporary directory"
+    # Use Microsoft's gen_modules_vhdx.sh script
+    echo "Creating modules VHDX using Microsoft's gen_modules_vhdx.sh script..."
+    if ! sudo ./Microsoft/scripts/gen_modules_vhdx.sh "${BUILD_DIR}/modules" "${KERNEL_RELEASE}" "${BUILD_DIR}/modules.vhdx"; then
+        echo "Error: Failed to create modules VHDX"
+        rm -rf "${BUILD_DIR}/modules"
         exit 1
     fi
     
-    # Create a blank image file
-    dd if=/dev/zero of="${TMP_DIR}/modules.img" bs=1024 count=$((MODULES_SIZE / 1024)) status=progress
-    
-    # Set up filesystem and mount
-    LO_DEV=$(sudo losetup --find --show "${TMP_DIR}/modules.img")
-    sudo mkfs -t ext4 "${LO_DEV}"
-    mkdir "${TMP_DIR}/modules_img"
-    sudo mount "${LO_DEV}" "${TMP_DIR}/modules_img"
-    sudo chmod a+rw "${TMP_DIR}/modules_img"
-    
-    # Copy over the modules
-    sudo cp -r "${BUILD_DIR}/modules/lib/modules/${KERNEL_RELEASE}"/* "${TMP_DIR}/modules_img"
-    sudo umount "${TMP_DIR}/modules_img"
-    sudo losetup -d "${LO_DEV}"
-    
-    # Convert to VHDX
-    qemu-img convert -O vhdx "${TMP_DIR}/modules.img" "${BUILD_DIR}/modules.vhdx"
-    
-    # Cleanup temporary files
-    rm -rf "${TMP_DIR}"
+    # Cleanup modules directory
     rm -rf "${BUILD_DIR}/modules"
     
     cat << EOF

--- a/build.sh
+++ b/build.sh
@@ -12,10 +12,10 @@ WSL2_KERNEL_VERSION="$(uname -r | grep -o '^[0-9\.]\+')"
 KERNEL_MAJOR_VERSION="$(echo "${WSL2_KERNEL_VERSION}" | cut -d. -f1)"
 
 # Validate kernel version was extracted correctly
-if [ -z "${KERNEL_MAJOR_VERSION}" ] || ! [[ "${KERNEL_MAJOR_VERSION}" =~ ^[0-9]+$ ]]; then
-    echo "Error: Could not determine kernel major version from: $(uname -r)"
-    echo "Expected format: X.Y.Z.W (e.g., 5.15.153.1 or 6.6.36.3)"
-    exit 1
+if [[ -z "${KERNEL_MAJOR_VERSION}" ]] || ! [[ "${KERNEL_MAJOR_VERSION}" =~ ^[0-9]+$ ]]; then
+  echo "Error: Could not determine kernel major version from: $(uname -r)"
+  echo "Expected format: X.Y.Z.W (e.g., 5.15.153.1 or 6.6.36.3)"
+  exit 1
 fi
 
 echo "Detected WSL2 kernel version: ${WSL2_KERNEL_VERSION} (major: ${KERNEL_MAJOR_VERSION})"
@@ -38,8 +38,8 @@ CONFIG_ZSTD_COMPRESS=y
 EOF
 
 # Add CONFIG_FRONTSWAP for kernel 5.x only (removed in 6.x)
-if [ "$KERNEL_MAJOR_VERSION" -lt 6 ]; then
-    cat << EOF >> .config
+if [[ "${KERNEL_MAJOR_VERSION}" -lt 6 ]]; then
+  cat << EOF >> .config
 CONFIG_FRONTSWAP=y
 EOF
 fi
@@ -61,33 +61,33 @@ make olddefconfig
 make -j $(nproc)
 
 # For kernel 6.x, also build and package modules
-if [ "$KERNEL_MAJOR_VERSION" -ge 6 ]; then
-    echo "Building and packaging kernel modules for WSL2 kernel 6.x..."
-    
-    # Save current directory
-    BUILD_DIR=$(pwd)
-    
-    # Install modules to a modules directory
-    if ! make modules_install INSTALL_MOD_PATH="${BUILD_DIR}/modules"; then
-        echo "Error: Failed to install kernel modules"
-        exit 1
-    fi
-    
-    # Get kernel release version
-    KERNEL_RELEASE=$(make -s kernelrelease)
-    
-    # Use Microsoft's gen_modules_vhdx.sh script
-    echo "Creating modules VHDX using Microsoft's gen_modules_vhdx.sh script..."
-    if ! sudo ./Microsoft/scripts/gen_modules_vhdx.sh "${BUILD_DIR}/modules" "${KERNEL_RELEASE}" "${BUILD_DIR}/modules.vhdx"; then
-        echo "Error: Failed to create modules VHDX"
-        rm -rf "${BUILD_DIR}/modules"
-        exit 1
-    fi
-    
-    # Cleanup modules directory
+if [[ "${KERNEL_MAJOR_VERSION}" -ge 6 ]]; then
+  echo "Building and packaging kernel modules for WSL2 kernel 6.x..."
+
+  # Save current directory
+  BUILD_DIR=$(pwd)
+
+  # Install modules to a modules directory
+  if ! make modules_install INSTALL_MOD_PATH="${BUILD_DIR}/modules"; then
+    echo "Error: Failed to install kernel modules"
+    exit 1
+  fi
+
+  # Get kernel release version
+  KERNEL_RELEASE=$(make -s kernelrelease)
+
+  # Use Microsoft's gen_modules_vhdx.sh script
+  echo "Creating modules VHDX using Microsoft's gen_modules_vhdx.sh script..."
+  if ! sudo ./Microsoft/scripts/gen_modules_vhdx.sh "${BUILD_DIR}/modules" "${KERNEL_RELEASE}" "${BUILD_DIR}/modules.vhdx"; then
+    echo "Error: Failed to create modules VHDX"
     rm -rf "${BUILD_DIR}/modules"
-    
-    cat << EOF
+    exit 1
+  fi
+
+  # Cleanup modules directory
+  rm -rf "${BUILD_DIR}/modules"
+
+  cat << EOF
 
 Kernel build complete for WSL2 kernel ${WSL2_KERNEL_VERSION}!
 
@@ -106,7 +106,7 @@ kernelModules=C:\\\\modules.vhdx
 Then reopen your WSL2 terminal. The new kernel with zswap support will be active.
 EOF
 else
-    cat << EOF
+  cat << EOF
 
 Kernel build complete for WSL2 kernel ${WSL2_KERNEL_VERSION}!
 

--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,7 @@ if [[ "${KERNEL_MAJOR_VERSION}" -ge 6 ]]; then
 
   # Cleanup modules directory and remove trap
   trap - EXIT
-  rm -rf "${BUILD_DIR}/modules"
+  cleanup_modules
 
   cat << EOF
 

--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,7 @@ if [ "$KERNEL_MAJOR_VERSION" -ge 6 ]; then
     
     # Create temporary directory for modules installation
     MODULES_TEMP=$(mktemp -d)
-    if [ ! -d "${MODULES_TEMP}" ]; then
+    if [ -z "${MODULES_TEMP}" ]; then
         echo "Error: Failed to create temporary directory"
         exit 1
     fi
@@ -66,7 +66,11 @@ if [ "$KERNEL_MAJOR_VERSION" -ge 6 ]; then
     BUILD_DIR=$(pwd)
     
     # Install modules to temporary directory
-    make modules_install INSTALL_MOD_PATH="${MODULES_TEMP}"
+    if ! make modules_install INSTALL_MOD_PATH="${MODULES_TEMP}"; then
+        echo "Error: Failed to install kernel modules"
+        rm -rf "${MODULES_TEMP}"
+        exit 1
+    fi
     
     # Create tar.gz archive of modules directly in build directory
     cd "${MODULES_TEMP}"

--- a/build.sh
+++ b/build.sh
@@ -18,43 +18,34 @@ cd "WSL2-Linux-Kernel-linux-msft-wsl-${WSL2_KERNEL_VERSION}"
 
 cp Microsoft/config-wsl .config           # Use WSL default kernel config as the base
 
-# Add zswap configuration based on kernel version
-if [ "$KERNEL_MAJOR_VERSION" -lt 6 ]; then
-    # Kernel 5.x configuration with CONFIG_FRONTSWAP
-    cat << EOF >> .config
+# Add zswap configuration
+# Common configuration for all kernel versions
+cat << EOF >> .config
 
 CONFIG_CRYPTO_ZSTD=y
 CONFIG_ZSTD_COMMON=y
 CONFIG_ZSTD_COMPRESS=y
 
-CONFIG_FRONTSWAP=y
-CONFIG_ZSWAP=y
-CONFIG_ZSWAP_COMPRESSOR_DEFAULT_ZSTD=y
-CONFIG_ZSWAP_COMPRESSOR_DEFAULT="zstd"
-CONFIG_ZSWAP_ZPOOL_DEFAULT_ZBUD=y
-CONFIG_ZSWAP_ZPOOL_DEFAULT="zbud"
-CONFIG_ZSWAP_DEFAULT_ON=y
-CONFIG_ZPOOL=y
-CONFIG_ZBUD=y
 EOF
-else
-    # Kernel 6.x configuration (CONFIG_FRONTSWAP removed)
+
+# Add CONFIG_FRONTSWAP for kernel 5.x only (removed in 6.x)
+if [ "$KERNEL_MAJOR_VERSION" -lt 6 ]; then
     cat << EOF >> .config
-
-CONFIG_CRYPTO_ZSTD=y
-CONFIG_ZSTD_COMMON=y
-CONFIG_ZSTD_COMPRESS=y
-
-CONFIG_ZSWAP=y
-CONFIG_ZSWAP_COMPRESSOR_DEFAULT_ZSTD=y
-CONFIG_ZSWAP_COMPRESSOR_DEFAULT="zstd"
-CONFIG_ZSWAP_ZPOOL_DEFAULT_ZBUD=y
-CONFIG_ZSWAP_ZPOOL_DEFAULT="zbud"
-CONFIG_ZSWAP_DEFAULT_ON=y
-CONFIG_ZPOOL=y
-CONFIG_ZBUD=y
+CONFIG_FRONTSWAP=y
 EOF
 fi
+
+# Add remaining zswap configuration (common to all versions)
+cat << EOF >> .config
+CONFIG_ZSWAP=y
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT_ZSTD=y
+CONFIG_ZSWAP_COMPRESSOR_DEFAULT="zstd"
+CONFIG_ZSWAP_ZPOOL_DEFAULT_ZBUD=y
+CONFIG_ZSWAP_ZPOOL_DEFAULT="zbud"
+CONFIG_ZSWAP_DEFAULT_ON=y
+CONFIG_ZPOOL=y
+CONFIG_ZBUD=y
+EOF
 
 make olddefconfig
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,16 @@ sudo apt update
 sudo apt install build-essential flex bison libssl-dev libelf-dev libncurses-dev autoconf libudev-dev libtool dwarves
 
 WSL2_KERNEL_VERSION="$(uname -r | grep -o '^[0-9\.]\+')"
-KERNEL_MAJOR_VERSION="$(echo ${WSL2_KERNEL_VERSION} | cut -d. -f1)"
+KERNEL_MAJOR_VERSION="$(echo "${WSL2_KERNEL_VERSION}" | cut -d. -f1)"
+
+# Validate kernel version was extracted correctly
+if [ -z "${KERNEL_MAJOR_VERSION}" ] || ! [[ "${KERNEL_MAJOR_VERSION}" =~ ^[0-9]+$ ]]; then
+    echo "Error: Could not determine kernel major version from: $(uname -r)"
+    echo "Expected format: X.Y.Z.W (e.g., 5.15.153.1 or 6.6.36.3)"
+    exit 1
+fi
+
+echo "Detected WSL2 kernel version: ${WSL2_KERNEL_VERSION} (major: ${KERNEL_MAJOR_VERSION})"
 
 wget -c https://github.com/microsoft/WSL2-Linux-Kernel/archive/refs/tags/linux-msft-wsl-${WSL2_KERNEL_VERSION}.tar.gz
 tar xvf linux-msft-wsl-${WSL2_KERNEL_VERSION}.tar.gz


### PR DESCRIPTION
This pull request improves the documentation and build process for compiling a WSL2 kernel with zswap support, adding clear instructions and automation for both kernel 5.x and 6.x versions. The changes enhance the user experience by providing version-aware build steps, automated module packaging for kernel 6.x, and detailed installation and verification guidance.

**Documentation improvements:**

* Expanded `README.md` to cover both kernel 5.x and 6.x, including step-by-step instructions for building, installing, and verifying zswap support, as well as quick start and one-liner usage options.

**Build process enhancements:**

* Updated `build.sh` to detect the kernel major version and validate its extraction, enabling conditional configuration and build steps for kernel 5.x versus 6.x.
* Automated the inclusion of appropriate kernel configuration options: adds `CONFIG_FRONTSWAP` only for kernel 5.x, and ensures all necessary zswap and zstd options are set for both versions.
* For kernel 6.x, added logic to build and package kernel modules into a `modules.vhdx` file using Microsoft's script, with error handling and cleanup.
* Improved post-build instructions in `build.sh` output, providing version-specific next steps for copying files and updating `.wslconfig`.